### PR TITLE
Add support for Kinesis using ATmega32U4

### DIFF
--- a/Makefile.lufa
+++ b/Makefile.lufa
@@ -1,6 +1,6 @@
 # Hey Emacs, this is a -*- makefile -*-
 #----------------------------------------------------------------------------
-# WinAVR Makefile Template written by Eric B. Weddington, Jörg Wunsch, et al.
+# WinAVR Makefile Template written by Eric B. Weddington, JÃ¶rg Wunsch, et al.
 #  >> Modified for use with the LUFA project. <<
 #
 # Released to the Public Domain
@@ -59,7 +59,7 @@
 #----------------------------------------------------------------------------
 
 # Select hardware variant
-HARDWARE_VARIANT = ERGODOX
+HARDWARE_VARIANT = KINESIS
 
 # By default, the Ergodox doesn't have any external eeprom. Unless one is added,
 # disable external storage.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To build for a USB-capable AVR using the LUFA library:
 Currently supported hardware variants for USB AVRs are:
 
 * ````ERGODOX```` (Ergodox, ATMega32u4 (Teensy))
+* ````KINESIS```` (Kinesis Advantage/Professional, ATMega32u4, wired according to https://cdn.hackaday.io/images/6612331423803438207.png)
 
 ## Usage
 

--- a/hardware/kinesis.h
+++ b/hardware/kinesis.h
@@ -350,13 +350,13 @@ extern const hid_keycode logical_to_hid_map_default[NUM_LOGICAL_KEYS] PROGMEM;
 #define INPUT_PIN5_PIN  PINC
 #define INPUT_PIN5_PORT PORTC
 #define INPUT_PIN5_DDR  DDRC
-#define INPUT_PIN5 (1<<6)
+#define INPUT_PIN5 (1<<7)
 
 // program key
 #define INPUT_PIN6_PIN  PINC
 #define INPUT_PIN6_PORT PORTC
 #define INPUT_PIN6_DDR  DDRC
-#define INPUT_PIN6 (1<<7)
+#define INPUT_PIN6 (1<<6)
 
 // FS1 and FS2 are PF0 and PF1
 

--- a/hardware/kinesis.h
+++ b/hardware/kinesis.h
@@ -327,6 +327,64 @@ extern const hid_keycode logical_to_hid_map_default[NUM_LOGICAL_KEYS] PROGMEM;
 #define EEPROM_SCL (1<<0)
 #define EEPROM_SDA (1<<1)
 
+#elif defined(__AVR_ATmega32U4__)
+// TMK / Warren Janssens Kinesis wiring
+
+// Continue using the same USB VID/PID pair that's assigned to the hardware
+#define USB_VENDOR_ID  0x1d50 // Openmoko, Inc
+#define USB_PRODUCT_ID 0x6028 // ErgoDox ergonomic keyboard
+
+#define USB_MANUFACTURER_STRING L"andreae.gen.nz"
+#define USB_PRODUCT_STRING L"Programmable USB Keyboard"
+#define USB_SERIAL_NUMBER_STRING L"andreae.gen.nz:ergodox"
+
+#define MATRIX_PORT PORTF
+#define MATRIX_DDR  DDRF
+#define MATRIX_SELECT_A (1<<4)
+#define MATRIX_SELECT_B (1<<5)
+#define MATRIX_SELECT_C (1<<6)
+#define MATRIX_SELECT_P138SEL (1<<7)
+#define MATRIX_MASK (MATRIX_SELECT_A | MATRIX_SELECT_B | MATRIX_SELECT_C | MATRIX_SELECT_P138SEL)
+
+// keypad key
+#define INPUT_PIN5_PIN  PINC
+#define INPUT_PIN5_PORT PORTC
+#define INPUT_PIN5_DDR  DDRC
+#define INPUT_PIN5 (1<<6)
+
+// program key
+#define INPUT_PIN6_PIN  PINC
+#define INPUT_PIN6_PORT PORTC
+#define INPUT_PIN6_DDR  DDRC
+#define INPUT_PIN6 (1<<7)
+
+// FS1 and FS2 are PF0 and PF1
+
+#define INPUT_REST_PIN  PINB
+#define INPUT_REST_PORT PORTB
+#define INPUT_REST_DDR  DDRB
+#define INPUT_REST (0xFF)
+
+#define LED_PORT PORTD
+#define LED_DDR  DDRD
+#define LED_CAPS (1<<7)
+#define LED_NUMLOCK (1<<4)
+#define LED_SCROLLLOCK (1<<5)
+#define LED_KEYPAD (1<<6)
+#define ALL_LEDS (LED_CAPS | LED_NUMLOCK | LED_SCROLLLOCK | LED_KEYPAD)
+
+#define USE_BUZZER 0
+
+#define BUZZER_PORT PORTE
+#define BUZZER_DDR DDRE
+#define BUZZER (1<<6)
+
+#define EEPROM_PORT PORTD
+#define EEPROM_DDR  DDRD
+#define EEPROM_PIN  PIND
+#define EEPROM_SCL (1<<0)
+#define EEPROM_SDA (1<<1)
+
 #else
 #error Ports not yet defined for this microcontroller
 #endif


### PR DESCRIPTION
Wired according to the TMK fork that supports Kinesis

Not sure if you are interested in merging this as it stands. Support for the Kinesis + mega32u4 is useful in some form, though.
