### PR TITLE
nix: update AVR toolchain dependencies for nix's new cross compilers

### DIFF
--- a/nix/firmware.nix
+++ b/nix/firmware.nix
@@ -65,7 +65,7 @@ let
     buildInputs = attrs.buildInputs ++ [ extractDefaultMappingEnv.wrappedRuby ];
     buildPhase = ''
       make -f Makefile.$HARDWARE_LIBRARY obj/hardware.o
-      ./qtclient/extract-default-mapping/extract-default-mapping.rb ${name}_default_mapping > extracted_mapping.c
+      ruby ./qtclient/extract-default-mapping/extract-default-mapping.rb ${name}_default_mapping > extracted_mapping.c
     '';
     installPhase = ''
       cp extracted_mapping.c $out

--- a/release.nix
+++ b/release.nix
@@ -3,7 +3,11 @@
 with pkgs;
 
 let
-  mkFirmware = callPackage ./nix/firmware.nix {};
+  mkFirmware = callPackage ./nix/firmware.nix {
+    avrgcc = pkgsCross.avr.buildPackages.gcc;
+    avrbinutils = pkgsCross.avr.buildPackages.binutils;
+    avrlibc = pkgsCross.avr.libcCross;
+  };
 in
 
 rec {


### PR DESCRIPTION
This breaks compatibility with 18.09, and builds with nixpkgs 19.03
and newer.