### PR TITLE
kinesis110: wait to settle after selecting a matrix row

### DIFF
--- a/hardware/kinesis110.c
+++ b/hardware/kinesis110.c
@@ -300,6 +300,11 @@ void matrix_select_row(uint8_t matrix_row){
 	}
 
 	MATRIX_PORT = (MATRIX_PORT & ~MATRIX_MASK) | output_port_val;
+
+	// Give some time to settle. Without this the y key produces "y6"
+	// and the 5 key produces "5t". Empirically >= 2us is sufficient,
+	// so let's add a slightly larger tolerance.
+	_delay_us(5);
 }
 
 uint8_t matrix_read_column(uint8_t matrix_column){


### PR DESCRIPTION
This was uncovered by 4dc04e1b2dbb175f88e3695e84fd55f4d70538e6, which
changed the sequence of row selection vs storage lookup. Previously
the sequence was:

  1. matrix_select_row
  2. storage_read_byte
  3. matrix_read_column

After the change, the sequence became:

  1. matrix_select_row
  2. matrix_read_column
  3. storage_read_byte

The duration of storage_read_byte was sufficient to let the state of
INPUT_PIN settle. Now we add a small delay to have the same effect.